### PR TITLE
Added missing include for tuple

### DIFF
--- a/lowtis/LowtisConfig.h
+++ b/lowtis/LowtisConfig.h
@@ -7,7 +7,7 @@
 
 namespace lowtis {
 
-class LowtisConfig;    
+struct LowtisConfig;
 typedef std::shared_ptr<LowtisConfig> LowtisConfigPtr;
 
 /*!

--- a/lowtis/LowtisConfig.h
+++ b/lowtis/LowtisConfig.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <memory>
+#include <tuple>
 
 namespace lowtis {
 


### PR DESCRIPTION
The **tuple** from std is used in the **LowtisConfig.h** in struct **LowtisConfig** before actual including of **tuple** header from std.

Consider compile unit **lowtis.cpp**, the first include is

```#include <lowtis/lowtis.h>```

The first include in lowtis.h is:

```#include <lowtis/LowtisConfig.h>```

So, std::tuple was used before including the header, which result in compiletime error on MSVC compiler.

Do not know how that works on GCC or clang, it might be the case that one of the headers **string** or **memory**  implicitly includes **tuple** (which they should not do, meaning that it is an issue in the standard library of those compilers).
