### PR TITLE
use rvalue reference for get_centercut input

### DIFF
--- a/lowtis/lowtis.h
+++ b/lowtis/lowtis.h
@@ -69,7 +69,7 @@ class ImageService {
     /*
      * Changes center cut configuration.
     */
-    void set_centercut(std::tuple<int, int>& centercut);
+    void set_centercut(const std::tuple<int, int>&& centercut);
 
   private:
     /*!

--- a/src/lowtis.cpp
+++ b/src/lowtis.cpp
@@ -40,7 +40,7 @@ void ImageService::pause()
     gmutex.unlock();
 }
 
-void ImageService::set_centercut(std::tuple<int, int>& centercut)
+void ImageService::set_centercut(const std::tuple<int, int>&& centercut)
 {
     config.centercut = centercut;
 }


### PR DESCRIPTION
A minor update to make the function more convenient to call.